### PR TITLE
Add centralized rate limiting mocks and refactor company enrichment tests

### DIFF
--- a/tests/mocks/external/rate-limiting.ts
+++ b/tests/mocks/external/rate-limiting.ts
@@ -1,0 +1,103 @@
+import { vi } from 'vitest';
+
+// Rate limiting mock configuration
+interface RateLimitMockConfig {
+  shouldAllow: boolean;
+  delay?: number;
+  error?: any;
+}
+
+class RateLimitingMocks {
+  private _config: RateLimitMockConfig = {
+    shouldAllow: true,
+    delay: 0
+  };
+
+  // Configuration methods
+  configure(config: Partial<RateLimitMockConfig>): void {
+    this._config = { ...this._config, ...config };
+  }
+
+  reset(): void {
+    this._config = {
+      shouldAllow: true,
+      delay: 0
+    };
+  }
+
+  // Helper method to execute with config
+  private async executeWithConfig(): Promise<boolean> {
+    if (this._config.delay) {
+      await new Promise(resolve => setTimeout(resolve, this._config.delay));
+    }
+
+    if (this._config.error) {
+      throw this._config.error;
+    }
+
+    return this._config.shouldAllow;
+  }
+
+  // Mock burst protection
+  checkBurstLimit = vi.fn(async (
+    identifier: string,
+    operation: string,
+    limit: number = 3,
+    window: string = '1m'
+  ): Promise<boolean> => {
+    return this.executeWithConfig();
+  });
+
+  // Convenience methods for test scenarios
+  mockRateLimitPass(): void {
+    this.configure({ shouldAllow: true });
+  }
+
+  mockRateLimitBlock(): void {
+    this.configure({ shouldAllow: false });
+  }
+
+  mockRateLimitError(error?: any): void {
+    this.configure({
+      error: error || new Error('Rate limiting service unavailable')
+    });
+  }
+
+  mockSlowRateLimit(delay: number = 1000): void {
+    this.configure({ delay });
+  }
+
+  // Reset all mocks
+  resetAllMocks(): void {
+    this.checkBurstLimit.mockReset();
+    this.reset();
+  }
+}
+
+// Export singleton instance
+export const rateLimitingMocks = new RateLimitingMocks();
+
+// Mock implementation for vi.mock()
+export const burstProtection = {
+  checkBurstLimit: rateLimitingMocks.checkBurstLimit
+};
+
+// Pre-configured test scenarios
+export const rateLimitTestScenarios = {
+  normalOperation: () => {
+    rateLimitingMocks.mockRateLimitPass();
+  },
+
+  rateLimitExceeded: () => {
+    rateLimitingMocks.mockRateLimitBlock();
+  },
+
+  rateLimitServiceDown: () => {
+    rateLimitingMocks.mockRateLimitError();
+  },
+
+  slowRateLimit: () => {
+    rateLimitingMocks.mockRateLimitPass();
+    rateLimitingMocks.mockSlowRateLimit(2000);
+  }
+};

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -10,6 +10,7 @@ import { anthropicMocks, openaiMocks, resendMocks, externalServicesMocks } from 
 import { googleApisMocks, gmailMocks } from './mocks/external/gmail';
 import { puppeteerModuleMocks, puppeteerMocks } from './mocks/external/puppeteer';
 import { axiomLogger, axiomMocks } from './mocks/external/axiom';
+import { burstProtection, rateLimitingMocks } from './mocks/external/rate-limiting';
 import { databaseQueryMocks } from './mocks/database/queries';
 
 // Polyfill for Node.js environment
@@ -51,6 +52,9 @@ vi.mock('@substack-intelligence/database', () => databaseMocks);
 
 // Mock Axiom logger with centralized mock
 vi.mock('../apps/web/lib/monitoring/axiom', () => ({ axiomLogger }));
+
+// Mock rate limiting with centralized mock
+vi.mock('../apps/web/lib/security/rate-limiting', () => ({ burstProtection }));
 
 // Mock Clerk authentication with centralized mocks
 vi.mock('@clerk/nextjs', () => clerkNextjsMocks);
@@ -159,6 +163,7 @@ afterEach(() => {
   // Reset all centralized mock factories
   try {
     axiomMocks.resetAllMocks();
+    rateLimitingMocks.resetAllMocks();
     clerkMocks.resetAllMocks();
     externalServicesMocks.resetAllMocks();
     gmailMocks.resetAllMocks();
@@ -237,6 +242,7 @@ globalThis.testUtils = {
   resetAllTestMocks: () => {
     try {
       axiomMocks.resetAllMocks();
+      rateLimitingMocks.resetAllMocks();
       clerkMocks.resetAllMocks();
       externalServicesMocks.resetAllMocks();
       gmailMocks.resetAllMocks();


### PR DESCRIPTION
## Summary
- Introduced a comprehensive rate limiting mock module for testing rate limiting scenarios
- Refactored company enrichment unit tests to use centralized mocks for rate limiting, database, and logging
- Improved test setup and teardown to reset all mocks consistently

## Changes

### New Rate Limiting Mocks
- Created `rateLimitingMocks` class with configurable behaviors: pass, block, error, and slow responses
- Added helper methods to easily simulate different rate limiting scenarios in tests
- Integrated rate limiting mocks into the global test setup for consistent mocking

### Test Refactoring
- Updated `company-enrichment.test.ts` and `company-enrichment-comprehensive.test.ts` to use centralized mocks:
  - Replaced inline mocks with imports from `mocks/external/rate-limiting`, `mocks/external/axiom`, and `mocks/database/supabase`
  - Used `DataFixtures` for consistent test data creation
  - Simplified mock implementations and improved readability
- Enhanced test coverage for rate limiting behavior, including blocking and error scenarios

### Test Setup Improvements
- Added rate limiting mocks to the global test setup and teardown routines
- Ensured all mocks are reset after each test to prevent state leakage

## Test plan
- Verified all existing company enrichment tests pass with the new centralized mocks
- Tested rate limiting scenarios explicitly to confirm correct handling of pass, block, and error cases
- Confirmed no regressions in enrichment logic or logging behavior through comprehensive unit tests

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6c2d6ba0-973d-4183-b23a-d99c5e4dd145