### PR TITLE
Fix pipeline metrics response consumption

### DIFF
--- a/apps/web/app/api/__tests__/pipeline-integration.test.ts
+++ b/apps/web/app/api/__tests__/pipeline-integration.test.ts
@@ -126,9 +126,8 @@ describe('Pipeline API Integration Tests', () => {
 
       expect(response.status).toBe(200);
       expect(data.success).toBe(true);
-      expect(data.data.metrics).toBeDefined();
-      expect(data.data.metrics.totalEmails).toBe(100);
-      expect(data.data.health).toBeDefined();
+      expect(data.metrics).toBeDefined();
+      expect(data.metrics.totalEmails).toBe(100);
       expect(data.meta.timestamp).toBeDefined();
     });
 

--- a/apps/web/app/api/pipeline/status/route.ts
+++ b/apps/web/app/api/pipeline/status/route.ts
@@ -34,14 +34,14 @@ export async function GET(request: NextRequest) {
 
     // Check cache first
     const cacheKey = `metrics:${userId}`;
-    const cachedMetrics = pipelineCacheManager.getPipelineMetrics();
-    
-    if (cachedMetrics) {
+    const cachedResponse = pipelineCacheManager.getPipelineMetrics();
+
+    if (cachedResponse) {
       console.log('[CACHE] Pipeline metrics served from cache');
-      
+
       return NextResponse.json(
-        performanceUtils.addCacheStatus(cachedMetrics, true, cacheKey),
-        { 
+        performanceUtils.addCacheStatus(cachedResponse, true, cacheKey),
+        {
           headers: performanceUtils.createCacheHeaders(30)
         }
       );

--- a/apps/web/components/dashboard/widgets/PipelineStatusWidget.tsx
+++ b/apps/web/components/dashboard/widgets/PipelineStatusWidget.tsx
@@ -86,17 +86,22 @@ export function PipelineStatusWidget() {
       
       const data = await response.json();
       
-      if (data.success && data.data?.metrics) {
-        const metrics = data.data.metrics;
-        const health = data.data.health;
-        
+      if (data.success && data.metrics) {
+        const metrics = data.metrics;
+
+        const nextRunEstimate = metrics.lastSyncTime
+          ? new Date(new Date(metrics.lastSyncTime).getTime() + 30 * 60 * 1000).toISOString()
+          : new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+        const isDataFresh = metrics.isFresh ?? false;
+
         // Transform API response to PipelineStatus format
         const pipelineStatus: PipelineStatus = {
-          status: health?.status === 'healthy' ? 'idle' : health?.status === 'warning' ? 'idle' : 'failed',
+          status: isDataFresh ? 'idle' : 'running',
           currentStep: '',
           progress: 0,
           lastRun: metrics.lastSyncTime || new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
-          nextRun: health?.suggestedNextSync || new Date(Date.now() + 1000 * 60 * 60).toISOString(),
+          nextRun: nextRunEstimate,
           steps: [
             { 
               name: 'Fetch Emails', 

--- a/apps/web/components/dashboard/widgets/__tests__/PipelineStatusWidget.test.tsx
+++ b/apps/web/components/dashboard/widgets/__tests__/PipelineStatusWidget.test.tsx
@@ -116,20 +116,18 @@ describe('PipelineStatusWidget', () => {
 
     const mockStatusResponse = {
       success: true,
-      data: {
-        metrics: {
-          totalEmails: 100,
-          totalCompanies: 50,
-          totalMentions: 200,
-          recentEmails: 10,
-          recentCompanies: 5,
-          lastSyncTime: new Date().toISOString()
-        },
-        health: {
-          status: 'healthy',
-          suggestedNextSync: new Date(Date.now() + 3600000).toISOString()
-        }
-      }
+      metrics: {
+        totalEmails: 100,
+        totalCompanies: 50,
+        totalMentions: 200,
+        recentEmails: 10,
+        recentCompanies: 5,
+        lastSyncTime: new Date().toISOString(),
+        dataAge: 10,
+        isFresh: true
+      },
+      trending: [],
+      meta: { timestamp: new Date().toISOString(), cached: false }
     };
 
     it('displays pipeline status when healthy', async () => {
@@ -172,15 +170,13 @@ describe('PipelineStatusWidget', () => {
             ok: true,
             json: () => Promise.resolve({
               ...mockStatusResponse,
-              data: {
-                ...mockStatusResponse.data,
-                metrics: {
-                  ...mockStatusResponse.data.metrics,
-                  recentEmails: 0, // No recent emails
-                  recentCompanies: 0,
-                  totalMentions: 0,
-                  totalCompanies: 0
-                }
+              metrics: {
+                ...mockStatusResponse.metrics,
+                recentEmails: 0, // No recent emails
+                recentCompanies: 0,
+                totalMentions: 0,
+                totalCompanies: 0,
+                isFresh: false
               }
             })
           } as Response);
@@ -207,17 +203,18 @@ describe('PipelineStatusWidget', () => {
 
     const mockStatusResponse = {
       success: true,
-      data: {
-        metrics: {
-          totalEmails: 100,
-          recentEmails: 10,
-          recentCompanies: 5,
-          totalCompanies: 50,
-          totalMentions: 200,
-          lastSyncTime: new Date().toISOString()
-        },
-        health: { status: 'healthy' }
-      }
+      metrics: {
+        totalEmails: 100,
+        recentEmails: 10,
+        recentCompanies: 5,
+        totalCompanies: 50,
+        totalMentions: 200,
+        lastSyncTime: new Date().toISOString(),
+        dataAge: 20,
+        isFresh: true
+      },
+      trending: [],
+      meta: { timestamp: new Date().toISOString(), cached: false }
     };
 
     it('triggers pipeline sync when Run Now button is clicked', async () => {
@@ -419,7 +416,17 @@ describe('PipelineStatusWidget', () => {
             ok: true,
             json: () => Promise.resolve({
               success: true,
-              data: { metrics: {}, health: { status: 'healthy' } }
+              metrics: {
+                totalEmails: 0,
+                totalCompanies: 0,
+                totalMentions: 0,
+                recentEmails: 0,
+                recentCompanies: 0,
+                lastSyncTime: new Date().toISOString(),
+                dataAge: 0,
+                isFresh: true
+              },
+              trending: []
             })
           } as Response);
         }

--- a/apps/web/contexts/IntelligenceContext.tsx
+++ b/apps/web/contexts/IntelligenceContext.tsx
@@ -109,7 +109,7 @@ export function IntelligenceProvider({ children }: { children: ReactNode }) {
       const data = await response.json();
       
       if (data.success) {
-        setMetrics(data.data.metrics);
+        setMetrics(data.metrics);
       }
     } catch (error) {
       console.error('Failed to refresh metrics:', error);


### PR DESCRIPTION
## Summary
- align the intelligence context and dashboard widget with the pipeline status API now returning metrics at the top level
- ensure cached pipeline status responses preserve the updated shape and adjust related integration/component tests accordingly

## Testing
- `pnpm vitest run apps/web/app/api/__tests__/pipeline-integration.test.ts apps/web/components/dashboard/widgets/__tests__/PipelineStatusWidget.test.tsx` *(configuration includes only tests/ directories, so no files were picked up)*
- `pnpm test -- --run` *(fails: existing suite requires Playwright/browser dependencies that are unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ed391be2c48327926c0630c0f4f1a6